### PR TITLE
docs: update branch discipline rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,8 @@
 
 Agents **MUST** enforce these rules at the start of **every single task/session**:
 
+**CRITICAL:** Always create a **NEW** branch for each feature/fix task. **NEVER** reuse old branches. If an old branch exists, create a new one with the updated description. This ensures zero collisions and clean history. Never stay on an old branch from a previous session – always switch to a new branch for the current task.
+
 ### 1.1 Always check current branch first
 
 ```bash


### PR DESCRIPTION
## Summary
Updated AGENTS.md to emphasize that agents must always create a new branch for each feature/fix task and never reuse old branches.

## Changes
- Added critical note in section 1 stating agents must create a NEW branch for each task
- Explicitly stated "Never stay on an old branch from a previous session"
- Ensures zero collisions and clean history

## Testing
Documentation-only change. No code changes.