### PR TITLE
fix: update progress stats when scrolling through cards

### DIFF
--- a/src/app/deck/[id]/deck-study-page.tsx
+++ b/src/app/deck/[id]/deck-study-page.tsx
@@ -76,6 +76,34 @@ export function DeckStudyPage({ deck }: DeckStudyPageProps) {
 		return () => window.removeEventListener("keydown", handleKeyDown);
 	}, [goToNextCard, goToPreviousCard]);
 
+	useEffect(() => {
+		const observers: IntersectionObserver[] = [];
+
+		cardRefs.current.forEach((cardEl, index) => {
+			if (!cardEl) return;
+
+			const observer = new IntersectionObserver(
+				(entries) => {
+					entries.forEach((entry) => {
+						if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+							setCurrentCardIndex(index);
+						}
+					});
+				},
+				{ threshold: 0.5 },
+			);
+
+			observer.observe(cardEl);
+			observers.push(observer);
+		});
+
+		return () => {
+			for (const observer of observers) {
+				observer.disconnect();
+			}
+		};
+	}, []);
+
 	if (isFinished) {
 		return (
 			<div className="h-[calc(100vh-120px)] flex flex-col items-center justify-center text-center space-y-8 animate-in fade-in zoom-in duration-500">


### PR DESCRIPTION
## Summary
- Added Intersection Observer to track which card is currently visible
- Progress bar and Card x/y stats now update when scrolling, not just via navigation buttons

## Fixes
- Resolves #47

## Technical Details
- Added `useEffect` with Intersection Observer that monitors each card
- Updates `currentCardIndex` when a card is 50%+ visible
- Properly cleans up observers on unmount