### PR TITLE
Correct spelling and grammar in deck JSON files

### DIFF
--- a/src/app/flashcards-demo/page.tsx
+++ b/src/app/flashcards-demo/page.tsx
@@ -1,53 +1,58 @@
-import { Flashcard } from "@/components/ui/flashcard"
+import { Flashcard } from "@/components/ui/flashcard";
 
 export default function FlashcardsDemo() {
-  const flashcards = [
-    {
-      id: "1",
-      question: "What is the difference between interface and type in TypeScript?",
-      answer: "Both can be used to describe the shape of an object but 'interface' can only describe an object shape and can be merged. 'type' can be an alias to primitives, unions, and tuples. Interfaces are generally preferred for object definitions.",
-      category: "TypeScript",
-      difficulty: "medium" as const
-    },
-    {
-      id: "2",
-      question: "Explain Closure in JavaScript.",
-      answer: "A closure is the combination of a function bundled together (enclosed) with references to its surrounding state (the lexical environment). In other words, a closure gives you access to an outer function's scope from an inner function.",
-      category: "JavaScript",
-      difficulty: "hard" as const
-    },
-    {
-      id: "3",
-      question: "What is the difference between useState and useRef in React?",
-      answer: "useState triggers re-renders when updated, while useRef does not. useRef is for persisting values without causing re-renders, often used for DOM elements or storing mutable values.",
-      category: "React",
-      difficulty: "easy" as const
-    }
-  ]
+	const flashcards = [
+		{
+			id: "1",
+			question:
+				"What is the difference between interface and type in TypeScript?",
+			answer:
+				"Both can be used to describe the shape of an object but 'interface' can only describe an object shape and can be merged. 'type' can be an alias to primitives, unions, and tuples. Interfaces are generally preferred for object definitions.",
+			category: "TypeScript",
+			difficulty: "medium" as const,
+		},
+		{
+			id: "2",
+			question: "Explain Closure in JavaScript.",
+			answer:
+				"A closure is the combination of a function bundled together (enclosed) with references to its surrounding state (the lexical environment). In other words, a closure gives you access to an outer function's scope from an inner function.",
+			category: "JavaScript",
+			difficulty: "hard" as const,
+		},
+		{
+			id: "3",
+			question: "What is the difference between useState and useRef in React?",
+			answer:
+				"useState triggers re-renders when updated, while useRef does not. useRef is for persisting values without causing re-renders, often used for DOM elements or storing mutable values.",
+			category: "React",
+			difficulty: "easy" as const,
+		},
+	];
 
-  return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black p-4">
-      <main className="flex w-full max-w-5xl flex-col items-center justify-center gap-8 py-12">
-        <h1 className="text-3xl font-bold text-center text-zinc-900 dark:text-zinc-50">
-          Flashcards Demo
-        </h1>
-        
-        <p className="text-center text-zinc-600 dark:text-zinc-400 max-w-lg">
-          Click on a flashcard to flip it and reveal the answer. Use keyboard navigation (Enter/Space) to flip cards.
-        </p>
-        
-        <div className="flex flex-col gap-6 mt-4 w-full max-w-2xl">
-          {flashcards.map((card) => (
-            <Flashcard 
-              key={card.id}
-              question={card.question}
-              answer={card.answer}
-              category={card.category}
-              difficulty={card.difficulty}
-            />
-          ))}
-        </div>
-      </main>
-    </div>
-  )
+	return (
+		<div className="flex min-h-screen items-center justify-center bg-zinc-50 font-sans dark:bg-black p-4">
+			<main className="flex w-full max-w-5xl flex-col items-center justify-center gap-8 py-12">
+				<h1 className="text-3xl font-bold text-center text-zinc-900 dark:text-zinc-50">
+					Flashcards Demo
+				</h1>
+
+				<p className="text-center text-zinc-600 dark:text-zinc-400 max-w-lg">
+					Click on a flashcard to flip it and reveal the answer. Use keyboard
+					navigation (Enter/Space) to flip cards.
+				</p>
+
+				<div className="flex flex-col gap-6 mt-4 w-full max-w-2xl">
+					{flashcards.map((card) => (
+						<Flashcard
+							key={card.id}
+							question={card.question}
+							answer={card.answer}
+							category={card.category}
+							difficulty={card.difficulty}
+						/>
+					))}
+				</div>
+			</main>
+		</div>
+	);
 }

--- a/src/data/agile.json
+++ b/src/data/agile.json
@@ -18,7 +18,7 @@
 		{
 			"id": "agile-008",
 			"question": "Vad är en working agreement?",
-			"answer": "En working agreement är ett sett av regler och normer som teamet gemensamt skapar för hur de ska arbeta tillsammans.",
+			"answer": "En working agreement är en uppsättning regler och normer som teamet gemensamt skapar för hur de ska arbeta tillsammans.",
 			"category": "behavioral",
 			"difficulty": "easy",
 			"tags": ["agile", "teamwork", "collaboration"],
@@ -40,7 +40,7 @@
 		{
 			"id": "agile-010",
 			"question": "Vad är agila värderingar?",
-			"answer": "Agila värderingar inkluderar individer framför processer, samarbete över kontrakt, fungerande mjukvara över dokumentation och responsivitet över följsamhet.",
+			"answer": "Agila värderingar inkluderar individer och interaktioner framför processer och verktyg, fungerande mjukvara framför omfattande dokumentation, kundsamarbete framför kontraktsförhandling och att reagera på förändring framför att följa en plan.",
 			"category": "behavioral",
 			"difficulty": "easy",
 			"tags": ["agile", "values", "principles"],
@@ -117,7 +117,7 @@
 		{
 			"id": "agile-017",
 			"question": "Vad är Definition of Done (DoD)?",
-			"answer": "Definition of Done är ett gemensamt avtal om vad som krävs för att ett arbete ska anses vara färdigt, inklusive tester och dokumentation.",
+			"answer": "Definition of Done (DoD) är en gemensam checklista för vad som krävs för att ett arbete ska anses vara färdigt, t.ex. tester, kodgranskning och dokumentation.",
 			"category": "behavioral",
 			"difficulty": "medium",
 			"tags": ["scrum", "quality", "standards"],

--- a/src/data/api.json
+++ b/src/data/api.json
@@ -1,7 +1,7 @@
 {
 	"id": "deck-api",
 	"name": "API-utveckling",
-	"description": "Flashcards om API:er, REST och backend-utveckling baserat på Lexicons github repos.",
+	"description": "Flashcards om API:er, REST och backend-utveckling baserat på Lexicons GitHub-repos.",
 	"category": "backend",
 	"cards": [
 		{
@@ -18,7 +18,7 @@
 		{
 			"id": "api-018",
 			"question": "Vad är GraphQL?",
-			"answer": "GraphQL är ett API-framställningsspråk som låter klienter specifikt begära den data de behöver, vilket minimerar over-fetching.",
+			"answer": "GraphQL är ett frågespråk för API:er som låter klienter specifikt begära den data de behöver, vilket minimerar over-fetching.",
 			"category": "backend",
 			"difficulty": "hard",
 			"tags": ["api", "graphql", "backend"],
@@ -95,7 +95,7 @@
 		{
 			"id": "api-025",
 			"question": "Vad är en API-endpoint?",
-			"answer": "En endpoint är en specifik URL där en API-förfrågling kan göras, t.ex. GET /api/users för att hämta användare.",
+			"answer": "En endpoint är en specifik URL där en API-förfrågan kan göras, t.ex. GET /api/users för att hämta användare.",
 			"category": "backend",
 			"difficulty": "easy",
 			"tags": ["api", "endpoint", "url"],

--- a/src/data/css.json
+++ b/src/data/css.json
@@ -73,7 +73,7 @@
 		{
 			"id": "css-007",
 			"question": "Vad är specificity i CSS?",
-			"answer": "Specificity bestämmer vilken CSS-regel som vinner vid konflikter. Den beräknas som en 4-delad vektor: inline styles, ID, klasser/attribut, elementer.",
+			"answer": "Specificity bestämmer vilken CSS-regel som vinner vid konflikter. Den beräknas som en 4-delad vektor: inline styles, ID, klasser/attribut, element.",
 			"category": "css",
 			"difficulty": "hard",
 			"tags": ["css", "specificity", "priority"],
@@ -150,7 +150,7 @@
 		{
 			"id": "css-014",
 			"question": "Vad är transitions i CSS?",
-			"answer": "Transitions låter dig animera övergångar mellan tillstånd, t.ex. vid hover. Du kan animera egenskaper som färg, storlek eller position medan dur och easing.",
+			"answer": "Transitions låter dig animera övergångar mellan tillstånd, t.ex. vid hover. Du kan animera egenskaper som färg, storlek eller position med duration och easing.",
 			"category": "frontend",
 			"difficulty": "easy",
 			"tags": ["css", "transitions", "animation"],
@@ -348,7 +348,7 @@
 		{
 			"id": "css-032",
 			"question": "Vad är subgrid i CSS Grid?",
-			"answer": "Subgrid låter child-elements i ett grid-nested att ärva spåringsdefinitionen från parent-grid för att skapa mer sammanhängande layouter.",
+			"answer": "Subgrid låter nästlade grid-element ärva spårdefinitionen från sitt föräldragrid för att skapa mer sammanhängande layouter.",
 			"category": "css",
 			"difficulty": "hard",
 			"tags": ["css", "grid", "subgrid"],

--- a/src/data/nextjs.json
+++ b/src/data/nextjs.json
@@ -73,7 +73,7 @@
 		{
 			"id": "nextjs-012",
 			"question": "Vad är Server Components?",
-			"answer": "Server Components körs på servern och är lämpliga för datahämtning och SEO, med minimal JavaScript-bördor på klienten.",
+			"answer": "Server Components körs på servern och är lämpliga för datahämtning och SEO, med minimal JavaScript-börda på klienten.",
 			"category": "frontend",
 			"difficulty": "medium",
 			"tags": ["nextjs", "server-components", "architecture"],
@@ -95,7 +95,7 @@
 		{
 			"id": "nextjs-014",
 			"question": "Vad är en API Route?",
-			"answer": "En API Route är ett endpoint i Next.js som låter dig skapa egna API:er genom att skapa filer i /app/api-mappen.",
+			"answer": "En API Route är en endpoint i Next.js som låter dig skapa egna API:er genom att skapa filer i /app/api-mappen.",
 			"category": "backend",
 			"difficulty": "medium",
 			"tags": ["nextjs", "api", "routes"],
@@ -139,7 +139,7 @@
 		{
 			"id": "nextjs-023",
 			"question": "Vad är App Router?",
-			"answer": "App Router är ett routing-system i Next.js baserat på mappstruktur i /app-katalogen, med stöd för layouts, pages och routes.",
+			"answer": "App Router är ett routingsystem i Next.js baserat på mappstrukturen i /app-katalogen, med stöd för layouter, sidor och rutter.",
 			"category": "frontend",
 			"difficulty": "medium",
 			"tags": ["nextjs", "routing", "app-router"],
@@ -249,7 +249,7 @@
 		{
 			"id": "nextjs-033",
 			"question": "Vad är intercepting routes i Next.js?",
-			"answer": "Intercepting routes tillåter att ladda en route inom en annan route som en modal utan att lämna den nuvarande sidan.",
+			"answer": "Intercepting routes tillåter att ladda en rutt inom en annan rutt som en modal utan att lämna den nuvarande sidan.",
 			"category": "frontend",
 			"difficulty": "hard",
 			"tags": ["nextjs", "routing", "intercepting"],

--- a/src/data/typescript.json
+++ b/src/data/typescript.json
@@ -61,8 +61,8 @@
 		},
 		{
 			"id": "typescript-032",
-			"question": "Vad är DOM manipulation?",
-			"answer": "DOM manipulation är processen att ändra HTML-dokumentets struktur, stil och innehåll med JavaScript.",
+			"question": "Vad är DOM-manipulation?",
+			"answer": "DOM-manipulation är processen att ändra HTML-dokumentets struktur, stil och innehåll med JavaScript.",
 			"category": "frontend",
 			"difficulty": "medium",
 			"tags": ["javascript", "dom", "manipulation"],
@@ -105,8 +105,8 @@
 		},
 		{
 			"id": "typescript-036",
-			"question": "Vad är en callback function?",
-			"answer": "En callback function är en funktion som skickas som argument till en annan funktion och körs när ett specifikt event inträffar.",
+			"question": "Vad är en callback-funktion?",
+			"answer": "En callback-funktion är en funktion som skickas som argument till en annan funktion och körs när en specifik händelse inträffar.",
 			"category": "backend",
 			"difficulty": "medium",
 			"tags": ["javascript", "callbacks", "functions"],
@@ -161,7 +161,7 @@
 		{
 			"id": "typescript-041",
 			"question": "Vad är en funktion i TypeScript?",
-			"answer": "En funktion är en återanvändbar kodblock som kan ta parametrar och returnera ett värde.",
+			"answer": "En funktion är ett återanvändbart kodblock som kan ta parametrar och returnera ett värde.",
 			"category": "backend",
 			"difficulty": "easy",
 			"tags": ["typescript", "functions", "programming"],
@@ -238,7 +238,7 @@
 		{
 			"id": "typescript-048",
 			"question": "Vad är access modifiers i TypeScript?",
-			"answer": "Access modifiers kontrollerar åtkomst till klassmedlemmar: public (standard), private (endast inom klassen), protected (inheriting klasser).",
+			"answer": "Access modifiers kontrollerar åtkomst till klassmedlemmar: public (standard), private (endast inom klassen), protected (ärvande klasser).",
 			"category": "backend",
 			"difficulty": "medium",
 			"tags": ["typescript", "class", "modifiers"],

--- a/src/data/wcag.json
+++ b/src/data/wcag.json
@@ -40,7 +40,7 @@
 		{
 			"id": "wcag-004",
 			"question": "Vad betyder WCAG Nivå A, AA och AAA?",
-			"answer": "Det är tre konformitetsnivåer. A är grundläggande krav, AA är den vanligaste standarden (rekommenderad), AAA är högsta nivån (strengast).",
+			"answer": "Det är tre konformitetsnivåer. A är grundläggande krav, AA är den vanligaste standarden (rekommenderad), AAA är högsta nivån (strängast).",
 			"category": "frontend",
 			"difficulty": "easy",
 			"tags": ["wcag", "levels", "conformance"],
@@ -106,7 +106,7 @@
 		{
 			"id": "wcag-010",
 			"question": "Vad är WCAG 1.3.1 Info and Relationships?",
-			"answer": "Information, struktur och relationer i innehåll måste kunna bestämas av programvara. Använd rätt HTML-element och semantic markup.",
+			"answer": "Information, struktur och relationer i innehåll måste kunna bestämmas av programvara. Använd rätt HTML-element och semantic markup.",
 			"category": "accessibility",
 			"difficulty": "medium",
 			"tags": ["wcag", "semantic", "structure"],
@@ -150,7 +150,7 @@
 		{
 			"id": "wcag-014",
 			"question": "Vad är WCAG 1.4.10 Reflow?",
-			"answer": "Innehåll måste visas utan att kräva horizontell scrolling när viewport är 320x256 pixlar. Detta gäller för responsiv design.",
+			"answer": "Innehåll måste visas utan att kräva horisontell scrolling när viewport är 320x256 pixlar. Detta gäller för responsiv design.",
 			"category": "accessibility",
 			"difficulty": "medium",
 			"tags": ["wcag", "reflow", "responsive"],
@@ -249,7 +249,7 @@
 		{
 			"id": "wcag-023",
 			"question": "Vad är WCAG 3.1.1 Language of Page?",
-			"answer": "Den default språket för varje sida måste kunna bestämmas av programvara. Använd lang-attributet på html-elementet (t.ex. lang=\"sv\").",
+			"answer": "Standardspråket för varje sida måste kunna bestämmas av programvara. Använd lang-attributet på html-elementet (t.ex. lang=\"sv\").",
 			"category": "frontend",
 			"difficulty": "easy",
 			"tags": ["wcag", "language", "html"],
@@ -260,7 +260,7 @@
 		{
 			"id": "wcag-024",
 			"question": "Vad är WCAG 2.1.2 No Keyboard Trap?",
-			"answer": "Om fokus kan placerats på ett element via tangentbord, måste det vara möjligt att förflytta fokus bort från det elementet med tangentbordet.",
+			"answer": "Om fokus kan placeras på ett element via tangentbord, måste det vara möjligt att förflytta fokus bort från det elementet med tangentbordet.",
 			"category": "accessibility",
 			"difficulty": "medium",
 			"tags": ["wcag", "keyboard", "focus"],
@@ -392,7 +392,7 @@
 		{
 			"id": "wcag-036",
 			"question": "Vad är WCAG 3.3.4 Error Prevention?",
-			"answer": "För transaktioner med juridiska eller finansiella konsekvenser ska data vara reversible, kontrollerbara eller bekräftas innan submission.",
+			"answer": "För transaktioner med juridiska eller finansiella konsekvenser ska data vara reversibla, kontrollerbara eller bekräftas innan inskickning.",
 			"category": "accessibility",
 			"difficulty": "medium",
 			"tags": ["wcag", "error-prevention", "forms"],

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,6 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+	return twMerge(clsx(inputs));
 }


### PR DESCRIPTION
The user requested a spelling check for the deck JSON files. This pull request addresses various linguistic errors and improves the overall quality of the flashcard content. Key changes include:
- Fixed Swedish spelling errors (e.g., 'horizontell' to 'horisontell', 'strengast' to 'strängast').
- Corrected grammatical gender and plural forms in Swedish (e.g., 'en kodblock' to 'ett kodblock').
- Refined technical terms and translations for better accuracy (e.g., 'API-framställningsspråk' to 'frågespråk').
- Applied Biome formatting rules to ensure consistency with the project's style.
- Verified the integrity of the JSON files through a successful project build and visual UI inspection using Playwright.

---
*PR created automatically by Jules for task [15244512441267327723](https://jules.google.com/task/15244512441267327723) started by @jine*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Swedish language clarity and accuracy across flashcard answers in Agile, API, CSS, Next.js, TypeScript, and WCAG decks.
  * Fixed spelling and grammar corrections in flashcard content for better readability and comprehension.

* **Style**
  * Updated code formatting standards for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->